### PR TITLE
SONARCSANA-153 Constructors should only call non-overridable methods

### DIFF
--- a/src/CSharp.CodeAnalysis/CodeAnalysis.csproj
+++ b/src/CSharp.CodeAnalysis/CodeAnalysis.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Helpers\EquivalenceChecker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rules\SillyBitwiseOperation.cs" />
+    <Compile Include="Rules\ConstructorOverridableCall.cs" />
     <Compile Include="Rules\DisposeFromDispose.cs" />
     <Compile Include="Rules\DisposeNotImplementingDispose.cs" />
     <Compile Include="Rules\RedundantCast.cs" />
@@ -369,6 +370,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Rules.Description\S2437.html" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Rules.Description\S1699.html" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/CSharp.CodeAnalysis/Rules.Description/S1699.html
+++ b/src/CSharp.CodeAnalysis/Rules.Description/S1699.html
@@ -1,0 +1,45 @@
+<p>
+    Calling an overridable method from a constructor could result in failures or strange behaviors when instantiating a subclass which overrides the method.
+</p>
+<p>
+    For example:
+</p>
+<ul>
+    <li>The subclass class constructor starts by calling the parent class constructor.</li>
+    <li>The parent class constructor calls the method, which has been overridden in the child class.</li>
+    <li>
+        If the behavior of the child class method depends on fields that are initialized in the child class constructor,
+        unexpected behavior (like a <code>NullReferenceException</code>) can result, because the fields aren't initialized yet.
+    </li>
+</ul>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class Parent 
+{
+  public Parent () 
+  {
+    DoSomething();  // Noncompliant
+  }
+
+  public virtual void DoSomething() // can be overridden
+  {  
+    ...
+  }
+}
+
+public class Child : Parent 
+{
+  private string foo;
+
+  public Child(string foo) // leads to call DoSomething() in Parent constructor which triggers a NullReferenceException as foo has not yet been initialized
+  {
+    this.foo = foo;
+  }
+
+  public override void DoSomething() 
+  {
+    Console.WriteLine(this.foo.Length);
+  }
+}
+</pre>

--- a/src/CSharp.CodeAnalysis/Rules/ConstructorOverridableCall.cs
+++ b/src/CSharp.CodeAnalysis/Rules/ConstructorOverridableCall.cs
@@ -1,0 +1,114 @@
+﻿/*
+ * SonarQube C# Code Analysis
+ * Copyright (C) 2015 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarQube.CSharp.CodeAnalysis.Common;
+using SonarQube.CSharp.CodeAnalysis.Common.Sqale;
+using SonarQube.CSharp.CodeAnalysis.Helpers;
+
+namespace SonarQube.CSharp.CodeAnalysis.Rules
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [SqaleConstantRemediation("10min")]
+    [SqaleSubCharacteristic(SqaleSubCharacteristic.ArchitectureReliability)]
+    [Rule(DiagnosticId, RuleSeverity, Title, IsActivatedByDefault)]
+    [Tags("bug")]
+    public class ConstructorOverridableCall : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S1699";
+        internal const string Title = "Constructors should only call non-overridable methods";
+        internal const string Description =
+            "Calling an overridable method from a constructor could result in failures or strange behaviors when instantiating " +
+            "a subclass which overrides the method.";
+        internal const string MessageFormat = "Remove this call from a constructor to the overridable \"{0}\" method.";
+        internal const string Category = "SonarQube";
+        internal const Severity RuleSeverity = Severity.Major;
+        internal const bool IsActivatedByDefault = true;
+
+        internal static readonly DiagnosticDescriptor Rule = 
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, 
+                RuleSeverity.ToDiagnosticSeverity(), IsActivatedByDefault, 
+                helpLinkUri: DiagnosticId.GetHelpLink(),
+                description: Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCodeBlockStartAction<SyntaxKind>(
+                cbc =>
+                {
+                    var calledVirtualMethods = ImmutableDictionary<InvocationExpressionSyntax, string>.Empty;
+
+                    var constructorDeclaration = cbc.CodeBlock as ConstructorDeclarationSyntax;
+                    if (constructorDeclaration == null)
+                    {
+                        return;
+                    }
+
+                    var constructorSymbol = cbc.SemanticModel.GetDeclaredSymbol(constructorDeclaration);
+                    if (constructorSymbol == null)
+                    {
+                        return;
+                    }
+
+                    cbc.RegisterSyntaxNodeAction(
+                        c =>
+                        {
+                            var invocationException = (InvocationExpressionSyntax) c.Node;
+                            var methodSymbol =
+                                c.SemanticModel.GetSymbolInfo(invocationException.Expression).Symbol as IMethodSymbol;
+                            var enclosingSymbol = c.SemanticModel.GetEnclosingSymbol(invocationException.SpanStart);
+                            if (methodSymbol == null ||
+                                enclosingSymbol == null ||
+                                !enclosingSymbol.Equals(constructorSymbol))
+                            {
+                                return;
+                            }
+
+                            if ((methodSymbol.IsVirtual ||
+                                 methodSymbol.IsAbstract) &&
+                                constructorSymbol.ContainingType.Equals(methodSymbol.ContainingType))
+                            {
+                                calledVirtualMethods = calledVirtualMethods.SetItem(invocationException,
+                                    methodSymbol.Name);
+                            }
+                        },
+                        SyntaxKind.InvocationExpression);
+
+                    cbc.RegisterCodeBlockEndAction(
+                        c =>
+                        {
+                            foreach (var calledVirtualMethod in calledVirtualMethods)
+                            {
+                                c.ReportDiagnostic(Diagnostic.Create(Rule, calledVirtualMethod.Key.Expression.GetLocation(),
+                                    calledVirtualMethod.Value));
+                            }
+                        });
+                });
+        }
+    }
+}

--- a/src/Tests/CSharp.CodeAnalysis.UnitTest/CodeAnalysis.UnitTest.csproj
+++ b/src/Tests/CSharp.CodeAnalysis.UnitTest/CodeAnalysis.UnitTest.csproj
@@ -118,6 +118,7 @@
     <Compile Include="MetricsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rules\SillyBitwiseOperationTest.cs" />
+    <Compile Include="Rules\ConstructorOverridableCallTest.cs" />
     <Compile Include="Rules\DisposeFromDisposeTest.cs" />
     <Compile Include="Rules\DisposeNotImplementingDisposeTest.cs" />
     <Compile Include="Rules\RedundantCastTest.cs" />
@@ -311,6 +312,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestCases\SillyBitwiseOperation.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestCases\ConstructorOverridableCall.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Compile Include="Verifier.cs" />

--- a/src/Tests/CSharp.CodeAnalysis.UnitTest/Rules/ConstructorOverridableCallTest.cs
+++ b/src/Tests/CSharp.CodeAnalysis.UnitTest/Rules/ConstructorOverridableCallTest.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarQube C# Code Analysis
+ * Copyright (C) 2015 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.CSharp.CodeAnalysis.Rules;
+
+namespace SonarQube.CSharp.CodeAnalysis.UnitTest.Rules
+{
+    [TestClass]
+    public class ConstructorOverridableCallTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void ConstructorOverridableCall()
+        {
+            Verifier.Verify(@"TestCases\ConstructorOverridableCall.cs", new ConstructorOverridableCall());
+        }
+    }
+}

--- a/src/Tests/CSharp.CodeAnalysis.UnitTest/TestCases/ConstructorOverridableCall.cs
+++ b/src/Tests/CSharp.CodeAnalysis.UnitTest/TestCases/ConstructorOverridableCall.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tests.Diagnostics
+{
+    public abstract class ParentAbstract
+    {
+        protected ParentAbstract()
+        {
+            DoSomething();  // Noncompliant
+
+            var action = new Action(() => { DoSomething(); });
+        }
+
+        public abstract void DoSomething();
+    }
+
+    public class Parent
+    {
+        public Parent()
+        {
+            DoSomething();  // Noncompliant
+            DoSomething2();
+
+            var action = new Action(() => { DoSomething(); });
+        }
+
+        public virtual void DoSomething() // can be overridden
+        {
+
+        }
+        public void DoSomething2()
+        {
+
+        }
+    }
+
+    public class Child : Parent
+    {
+        private string foo;
+
+        public Child(string foo) // leads to call DoSomething() in Parent constructor which triggers a NullReferenceException as foo has not yet been initialized
+        {
+            this.foo = foo;
+        }
+
+        public override void DoSomething()
+        {
+            Console.WriteLine(this.foo.Length);
+        }
+    }
+}

--- a/src/Tests/SonarQube.CSharp.CodeAnalysis.RulingTest/Expected/S1699.json
+++ b/src/Tests/SonarQube.CSharp.CodeAnalysis.RulingTest/Expected/S1699.json
@@ -1,0 +1,94 @@
+{
+  "Version": "0.1",
+  "ToolInfo": {
+    "ToolName": "SonarQube.CSharp.CodeAnalysis.RulingTest",
+    "FileVersion": "1.0.0"
+  },
+  "Issues": [
+    {
+      "RuleId": "S1699",
+      "FullMessage": "Remove this call from a constructor to the overridable \"SetModel\" method.",
+      "Locations": [
+        {
+          "AnalysisTarget": {
+            "Uri": "\\Mvc-dev_b245996949\\src\\Microsoft.AspNet.Mvc.Extensions\\ViewDataDictionary.cs",
+            "Region": {
+              "StartLine": 204,
+              "EndLine": 204,
+              "StartColumn": 0,
+              "EndColumn": 2147483647
+            }
+          }
+        }
+      ]
+    },
+    {
+      "RuleId": "S1699",
+      "FullMessage": "Remove this call from a constructor to the overridable \"LoadVolumes\" method.",
+      "Locations": [
+        {
+          "AnalysisTarget": {
+            "Uri": "\\sharpcompress_b855fd5bf0d1\\SharpCompress\\Archive\\AbstractArchive.cs",
+            "Region": {
+              "StartLine": 32,
+              "EndLine": 32,
+              "StartColumn": 0,
+              "EndColumn": 2147483647
+            }
+          }
+        }
+      ]
+    },
+    {
+      "RuleId": "S1699",
+      "FullMessage": "Remove this call from a constructor to the overridable \"LoadEntries\" method.",
+      "Locations": [
+        {
+          "AnalysisTarget": {
+            "Uri": "\\sharpcompress_b855fd5bf0d1\\SharpCompress\\Archive\\AbstractArchive.cs",
+            "Region": {
+              "StartLine": 33,
+              "EndLine": 33,
+              "StartColumn": 0,
+              "EndColumn": 2147483647
+            }
+          }
+        }
+      ]
+    },
+    {
+      "RuleId": "S1699",
+      "FullMessage": "Remove this call from a constructor to the overridable \"LoadEntries\" method.",
+      "Locations": [
+        {
+          "AnalysisTarget": {
+            "Uri": "\\sharpcompress_b855fd5bf0d1\\SharpCompress\\Archive\\AbstractArchive.cs",
+            "Region": {
+              "StartLine": 44,
+              "EndLine": 44,
+              "StartColumn": 0,
+              "EndColumn": 2147483647
+            }
+          }
+        }
+      ]
+    },
+    {
+      "RuleId": "S1699",
+      "FullMessage": "Remove this call from a constructor to the overridable \"clean\" method.",
+      "Locations": [
+        {
+          "AnalysisTarget": {
+            "Uri": "\\sharpcompress_b855fd5bf0d1\\SharpCompress\\Compressor\\PPMd\\H\\SubAllocator.cs",
+            "Region": {
+              "StartLine": 107,
+              "EndLine": 107,
+              "StartColumn": 0,
+              "EndColumn": 2147483647
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/Tests/SonarQube.CSharp.CodeAnalysis.RulingTest/SonarQube.CodeAnalysis.RulingTest.csproj
+++ b/src/Tests/SonarQube.CSharp.CodeAnalysis.RulingTest/SonarQube.CodeAnalysis.RulingTest.csproj
@@ -241,6 +241,9 @@
     <None Include="Expected\S1697.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Expected\S1699.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Expected\S1764.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
After implementing this rule, I realized that it also exists in FxCop. Its ID is CA2214 (http://source.roslyn.codeplex.com/#Microsoft.AnalyzerPowerPack.CSharp/Usage/CSharpCA2214DiagnosticAnalyzer.cs), and is already implemented by the Roslyn team. (It is not a general compiler error, and it is also implemented by Resharper)